### PR TITLE
Split item pick and forage for TBB

### DIFF
--- a/bash/install_snevo.sh
+++ b/bash/install_snevo.sh
@@ -7,4 +7,4 @@ ml load tbb/4.4.2.152
 
 # here working in R
 Rscript --slave -e 'devtools::build()'
-Rscript --slave -e 'sink("install_log.log"); devtools::install(); sink()'
+Rscript --slave -e 'sink("install_log.log"); devtools::install(upgrade = "never"); sink()'

--- a/src/agents.cpp
+++ b/src/agents.cpp
@@ -300,7 +300,8 @@ void Population::move(Resources &food, const int nThreads) {
     );
 }
 
-void Population::forage(Resources &food, const int nThreads){
+// function to paralellise choice of forage item
+std::vector<int> Population::pickForageItem(const Resources &food, const int nThreads){
     shufflePop();
     // nearest food
     std::vector<int> idTargetFood (nAgents, -1);
@@ -330,6 +331,9 @@ void Population::forage(Resources &food, const int nThreads){
             }
         }
     );
+
+    return idTargetFood;
+}
 
     // all agents have picked a food item if they can forage
     // now forage in a serial loop --- this cannot be parallelised

--- a/src/agents.cpp
+++ b/src/agents.cpp
@@ -335,6 +335,10 @@ std::vector<int> Population::pickForageItem(const Resources &food, const int nTh
     return idTargetFood;
 }
 
+// function to exploitatively forage on picked forage items
+void Population::doForage(Resources &food, const int nThreads) {
+    std::vector<int> idTargetFood = pickForageItem(food, nThreads);
+
     // all agents have picked a food item if they can forage
     // now forage in a serial loop --- this cannot be parallelised
     // this order is randomised

--- a/src/agents.cpp
+++ b/src/agents.cpp
@@ -301,7 +301,7 @@ void Population::move(const Resources &food, const int nThreads) {
 }
 
 // function to paralellise choice of forage item
-std::vector<int> Population::pickForageItem(const Resources &food, const int nThreads){
+void Population::pickForageItem(const Resources &food, const int nThreads){
     shufflePop();
     // nearest food
     std::vector<int> idTargetFood (nAgents, -1);
@@ -332,13 +332,11 @@ std::vector<int> Population::pickForageItem(const Resources &food, const int nTh
         }
     );
 
-    return idTargetFood;
+    forageItem = idTargetFood;
 }
 
 // function to exploitatively forage on picked forage items
 void Population::doForage(Resources &food, const int nThreads) {
-    std::vector<int> idTargetFood = pickForageItem(food, nThreads);
-
     // all agents have picked a food item if they can forage
     // now forage in a serial loop --- this cannot be parallelised
     // this order is randomised
@@ -348,7 +346,7 @@ void Population::doForage(Resources &food, const int nThreads) {
         if ((counter[id] > 0) | (food.nAvailable == 0)) {
             // nothing
         } else {
-            int thisItem = idTargetFood[id]; //the item picked by this agent
+            int thisItem = forageItem[id]; //the item picked by this agent
             // check selected item is available
             if (thisItem != -1)
             {

--- a/src/agents.cpp
+++ b/src/agents.cpp
@@ -119,7 +119,7 @@ std::vector<int> Population::getNeighbourId (
 
 // general function for items within distance
 int Population::countFood (
-    Resources &food,
+    const Resources &food,
     const float xloc, const float yloc) {
 
     int nFood = 0;
@@ -146,7 +146,7 @@ int Population::countFood (
 
 // function for the nearest available food item
 std::vector<int> Population::getFoodId (
-    Resources &food,
+    const Resources &food,
     const float xloc, const float yloc) {
         
     std::vector<int> food_id;
@@ -178,7 +178,7 @@ std::normal_distribution<float> noise(0.f, 0.0001f);
 std::cauchy_distribution<float> noise_cauchy(0.f, 0.001f);
 
 /// population movement function
-void Population::move(Resources &food, const int nThreads) {
+void Population::move(const Resources &food, const int nThreads) {
 
     float twopi = 2.f * M_PI;
     

--- a/src/agents.hpp
+++ b/src/agents.hpp
@@ -109,10 +109,10 @@ public:
     void updateRtree();
 
     int countFood (
-        Resources &food, const float xloc, const float yloc);
+        const Resources &food, const float xloc, const float yloc);
     
     std::vector<int> getFoodId (
-        Resources &food,
+        const Resources &food,
         const float xloc, const float yloc
     );
     
@@ -124,8 +124,9 @@ public:
     );
 
     // functions to move and forage on a landscape
-    void move(Resources &food, const int nThreads);
-    void forage(Resources &food, const int nThreads);
+    void move(const Resources &food, const int nThreads);
+    std::vector<int> pickForageItem(const Resources &food, const int nThreads);
+    void doForage(Resources &food, const int nThreads);
     
     // funs to handle fitness and reproduce
     std::vector<float> handleFitness();

--- a/src/agents.hpp
+++ b/src/agents.hpp
@@ -43,6 +43,7 @@ public:
 
         // vectors for agent order, infection status, time infected
         order(popsize, 1),
+        forageItem(popsize, -1),
         infected(popsize, false),//,
         timeInfected(popsize, 0),
 
@@ -82,6 +83,7 @@ public:
 
     // shuffle vector and transmission
     std::vector<int> order;
+    std::vector<int> forageItem;
     std::vector<bool> infected;
     std::vector<int> timeInfected;
     float pTransmit;
@@ -125,7 +127,7 @@ public:
 
     // functions to move and forage on a landscape
     void move(const Resources &food, const int nThreads);
-    std::vector<int> pickForageItem(const Resources &food, const int nThreads);
+    void pickForageItem(const Resources &food, const int nThreads);
     void doForage(Resources &food, const int nThreads);
     
     // funs to handle fitness and reproduce

--- a/src/simulations.cpp
+++ b/src/simulations.cpp
@@ -47,19 +47,28 @@ Rcpp::List simulation::do_simulation() {
         
     }
 
+    Rcpp::Rcout << "spillover in gen: " << gen_init << "\n";
+
     // go over gens
     for(int gen = 0; gen < genmax; gen++) {
+
+        Rcpp::Rcout << "gen = " << gen << "\n";
+
         // food.initResources();
         food.countAvailable();
-        // Rcpp::Rcout << "food available = " << food.nAvailable << "\n";
+        Rcpp::Rcout << "food available = " << food.nAvailable << "\n";
 
         // reset counter and positions
         pop.counter = std::vector<int> (pop.nAgents, 0);
+        Rcpp::Rcout << "resetting agent counter\n";
         // pop.initPos(food);
 
         if((scenario > 0) && (gen > gen_init)) {
             pop.introducePathogen(initialInfections);
         }
+        Rcpp::Rcout << "introduced pathogen if applicable\n";
+
+        Rcpp::Rcout << "entering ecological timescale\n";
 
         // timesteps start here
         for (size_t t = 0; t < static_cast<size_t>(tmax); t++)

--- a/src/simulations.cpp
+++ b/src/simulations.cpp
@@ -87,8 +87,11 @@ Rcpp::List simulation::do_simulation() {
                 mdPost.updateMoveData(pop, t);
             }
 
-            // foraging
-            pop.forage(food, nThreads);
+            // foraging -- split into parallelised picking
+            // and non-parallel exploitation
+            pop.pickForageItem(food, nThreads);
+            pop.doForage(food, nThreads);
+
             // count associations
             pop.countAssoc(nThreads);
             if((scenario > 0) && (gen > gen_init)) {


### PR DESCRIPTION
Splitting the population wide function `forage` into `pickItem` and `doForage` to pass `Resources` by const reference in `pickItem`, and by reference (modifiable) in `doForage`. This allows `pickItem` to be multi-threaded using TBB, while keeping the overall `doForage` single-thread to prevent memory issues white using an HPC cluster.