### PR TITLE
Add scenario 3 for sporadic introductions

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -19,7 +19,10 @@ get_test_landscape <- function(nItems, landsize, nClusters, clusterSpread, regen
 #' arguments to the corresponding R function.
 #'
 #' @param scenario The pathomove scenario: 0 for no pathogen, 1 for 
-#' persistent introduction across generations, and 2 for a single introduction.
+#' persistent introduction across generations, 
+#' 2 for a single introduction,
+#' and 3 for sporadic introductions drawn from a geometric distribution
+#' specified by `spillover_rate`.
 #' @param popsize The population size.
 #' @param nItems How many food items on the landscape.
 #' @param landsize The size of the landscape as a numeric (double).
@@ -58,9 +61,12 @@ get_test_landscape <- function(nItems, landsize, nClusters, clusterSpread, regen
 #' While high, this may be more appropriate for a small population; change this
 #' value and \code{popsize} to test the simulation's sensitivity to these values.
 #' @param mSize Controls the mutational step size, and represents the scale
-#' parameter of a Cauchy distribution. 
+#' parameter of a Cauchy distribution.
+#' @param spillover_rate For scenario 3, the probability parameter _p_ of a
+#' geometric distribution from which the number of generations until the next
+#' pathogen introduction are drawn.
 #' @return An S4 class, `pathomove_output`, with simulation outcomes.
-run_pathomove <- function(scenario, popsize, nItems, landsize, nClusters, clusterSpread, tmax, genmax, g_patho_init, range_food, range_agents, range_move, handling_time, regen_time, pTransmit, initialInfections, costInfect, nThreads, dispersal, infect_percent, vertical, mProb, mSize) {
-    .Call(`_pathomove_run_pathomove`, scenario, popsize, nItems, landsize, nClusters, clusterSpread, tmax, genmax, g_patho_init, range_food, range_agents, range_move, handling_time, regen_time, pTransmit, initialInfections, costInfect, nThreads, dispersal, infect_percent, vertical, mProb, mSize)
+run_pathomove <- function(scenario, popsize, nItems, landsize, nClusters, clusterSpread, tmax, genmax, g_patho_init, range_food, range_agents, range_move, handling_time, regen_time, pTransmit, initialInfections, costInfect, nThreads, dispersal, infect_percent, vertical, mProb, mSize, spillover_rate) {
+    .Call(`_pathomove_run_pathomove`, scenario, popsize, nItems, landsize, nClusters, clusterSpread, tmax, genmax, g_patho_init, range_food, range_agents, range_move, handling_time, regen_time, pTransmit, initialInfections, costInfect, nThreads, dispersal, infect_percent, vertical, mProb, mSize, spillover_rate)
 }
 

--- a/R/class_pathomove_output.R
+++ b/R/class_pathomove_output.R
@@ -25,6 +25,7 @@ check_pathomove_output <- function(object) {
 #' @slot agent_parameters list.
 #' @slot eco_parameters list.
 #' @slot generations integer.
+#' @slot gens_patho_intro integer.
 #' @slot infections_per_gen integer.
 #' @slot trait_data list.
 #' @slot edge_list list.
@@ -40,6 +41,7 @@ setClass(
     agent_parameters = "list",
     eco_parameters = "list",
     generations = "integer",
+    gens_patho_intro = "integer",
     infections_per_gen = "integer",
     trait_data = "list",
     edge_lists = "list",
@@ -51,6 +53,7 @@ setClass(
     agent_parameters = list(),
     eco_parameters = list(),
     generations = NA_integer_,
+    gens_patho_intro = NA_integer_,
     infections_per_gen = NA_integer_,
     trait_data = list(),
     edge_lists = list(),

--- a/man/pathomove_output-class.Rd
+++ b/man/pathomove_output-class.Rd
@@ -16,6 +16,8 @@ Defines the \code{pathomove_output} class.
 
 \item{\code{generations}}{integer.}
 
+\item{\code{gens_patho_intro}}{integer.}
+
 \item{\code{infections_per_gen}}{integer.}
 
 \item{\code{trait_data}}{list.}

--- a/man/run_pathomove.Rd
+++ b/man/run_pathomove.Rd
@@ -27,12 +27,16 @@ run_pathomove(
   infect_percent,
   vertical,
   mProb,
-  mSize
+  mSize,
+  spillover_rate
 )
 }
 \arguments{
 \item{scenario}{The pathomove scenario: 0 for no pathogen, 1 for
-persistent introduction across generations, and 2 for a single introduction.}
+persistent introduction across generations,
+2 for a single introduction,
+and 3 for sporadic introductions drawn from a geometric distribution
+specified by \code{spillover_rate}.}
 
 \item{popsize}{The population size.}
 
@@ -94,6 +98,10 @@ value and \code{popsize} to test the simulation's sensitivity to these values.}
 
 \item{mSize}{Controls the mutational step size, and represents the scale
 parameter of a Cauchy distribution.}
+
+\item{spillover_rate}{For scenario 3, the probability parameter \emph{p} of a
+geometric distribution from which the number of generations until the next
+pathogen introduction are drawn.}
 }
 \value{
 An S4 class, \code{pathomove_output}, with simulation outcomes.

--- a/scripts/check_pkg_install.R
+++ b/scripts/check_pkg_install.R
@@ -14,7 +14,6 @@ detach(package:pathomove)
 library(pathomove)
 library(data.table)
 library(ggplot2)
-library(data.table)
 
 l <- pathomove::get_test_landscape(
   nItems = 1800,
@@ -176,7 +175,7 @@ ggraph(g, layout = "mds") +
   geom_edge_link()
 
 #### check S4 class output ####
-a = pathomove::run_pathomove_s4(
+a = pathomove::run_pathomove(
   scenario = 2,
   popsize = 500,
   nItems = 1800,
@@ -256,3 +255,33 @@ ggplot(sdf)+
   geom_col(
     aes(gen, N, fill = as.factor(infect_src))
   )
+
+#### check sporadic spillover ####
+a = pathomove::run_pathomove(
+  scenario = 3,
+  popsize = 300,
+  nItems = 1800,
+  landsize = 60,
+  nClusters = 60,
+  clusterSpread = 1,
+  tmax = 100,
+  genmax = 500,
+  g_patho_init = 250,
+  range_food = 1,
+  range_agents = 1,
+  range_move = 1,
+  handling_time = 5,
+  regen_time = 50,
+  pTransmit = 0.05,
+  initialInfections = 20,
+  costInfect = 0.25,
+  nThreads = 2,
+  dispersal = 3.0, # for local-ish dispersal
+  infect_percent = FALSE,
+  vertical = F,
+  mProb = 0.01,
+  mSize = 0.01,
+  spillover_rate = 0.5
+)
+
+plot(a@generations, a@infections_per_gen, type = "b")

--- a/scripts/check_pkg_install.R
+++ b/scripts/check_pkg_install.R
@@ -258,15 +258,15 @@ ggplot(sdf)+
 
 #### check sporadic spillover ####
 a = pathomove::run_pathomove(
-  scenario = 3,
-  popsize = 300,
+  scenario = 1,
+  popsize = 500,
   nItems = 1800,
   landsize = 60,
   nClusters = 60,
   clusterSpread = 1,
   tmax = 100,
   genmax = 500,
-  g_patho_init = 250,
+  g_patho_init = 300,
   range_food = 1,
   range_agents = 1,
   range_move = 1,
@@ -274,14 +274,40 @@ a = pathomove::run_pathomove(
   regen_time = 50,
   pTransmit = 0.05,
   initialInfections = 20,
-  costInfect = 0.25,
+  costInfect = 0.5,
   nThreads = 2,
-  dispersal = 3.0, # for local-ish dispersal
+  dispersal = 2.0, # for local-ish dispersal
   infect_percent = FALSE,
   vertical = F,
   mProb = 0.01,
   mSize = 0.01,
-  spillover_rate = 0.5
+  spillover_rate = 0.01
 )
 
 plot(a@generations, a@infections_per_gen, type = "b")
+
+a@gens_patho_intro
+
+b = pathomove::get_trait_data(a)
+pathomove::get_social_strategy(b)
+
+d = b[, .N, by = c("gen", "social_strat")]
+
+ggplot(d)+
+  geom_col(
+    aes(
+      gen, N, fill = social_strat
+    )
+  )
+# +
+#   geom_vline(
+#     xintercept = a@gens_patho_intro
+#   )
+
+ggplot(b)+
+  stat_summary(
+    aes(
+      gen, energy
+    ),
+    binwidth = c(100, NA)
+  )

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -26,8 +26,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // run_pathomove
-S4 run_pathomove(const int scenario, const int popsize, const int nItems, const float landsize, const int nClusters, const float clusterSpread, const int tmax, const int genmax, const int g_patho_init, const float range_food, const float range_agents, const float range_move, const int handling_time, const int regen_time, float pTransmit, const int initialInfections, const float costInfect, const int nThreads, const float dispersal, const bool infect_percent, const bool vertical, const float mProb, const float mSize);
-RcppExport SEXP _pathomove_run_pathomove(SEXP scenarioSEXP, SEXP popsizeSEXP, SEXP nItemsSEXP, SEXP landsizeSEXP, SEXP nClustersSEXP, SEXP clusterSpreadSEXP, SEXP tmaxSEXP, SEXP genmaxSEXP, SEXP g_patho_initSEXP, SEXP range_foodSEXP, SEXP range_agentsSEXP, SEXP range_moveSEXP, SEXP handling_timeSEXP, SEXP regen_timeSEXP, SEXP pTransmitSEXP, SEXP initialInfectionsSEXP, SEXP costInfectSEXP, SEXP nThreadsSEXP, SEXP dispersalSEXP, SEXP infect_percentSEXP, SEXP verticalSEXP, SEXP mProbSEXP, SEXP mSizeSEXP) {
+S4 run_pathomove(const int scenario, const int popsize, const int nItems, const float landsize, const int nClusters, const float clusterSpread, const int tmax, const int genmax, const int g_patho_init, const float range_food, const float range_agents, const float range_move, const int handling_time, const int regen_time, float pTransmit, const int initialInfections, const float costInfect, const int nThreads, const float dispersal, const bool infect_percent, const bool vertical, const float mProb, const float mSize, const float spillover_rate);
+RcppExport SEXP _pathomove_run_pathomove(SEXP scenarioSEXP, SEXP popsizeSEXP, SEXP nItemsSEXP, SEXP landsizeSEXP, SEXP nClustersSEXP, SEXP clusterSpreadSEXP, SEXP tmaxSEXP, SEXP genmaxSEXP, SEXP g_patho_initSEXP, SEXP range_foodSEXP, SEXP range_agentsSEXP, SEXP range_moveSEXP, SEXP handling_timeSEXP, SEXP regen_timeSEXP, SEXP pTransmitSEXP, SEXP initialInfectionsSEXP, SEXP costInfectSEXP, SEXP nThreadsSEXP, SEXP dispersalSEXP, SEXP infect_percentSEXP, SEXP verticalSEXP, SEXP mProbSEXP, SEXP mSizeSEXP, SEXP spillover_rateSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -54,7 +54,8 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const bool >::type vertical(verticalSEXP);
     Rcpp::traits::input_parameter< const float >::type mProb(mProbSEXP);
     Rcpp::traits::input_parameter< const float >::type mSize(mSizeSEXP);
-    rcpp_result_gen = Rcpp::wrap(run_pathomove(scenario, popsize, nItems, landsize, nClusters, clusterSpread, tmax, genmax, g_patho_init, range_food, range_agents, range_move, handling_time, regen_time, pTransmit, initialInfections, costInfect, nThreads, dispersal, infect_percent, vertical, mProb, mSize));
+    Rcpp::traits::input_parameter< const float >::type spillover_rate(spillover_rateSEXP);
+    rcpp_result_gen = Rcpp::wrap(run_pathomove(scenario, popsize, nItems, landsize, nClusters, clusterSpread, tmax, genmax, g_patho_init, range_food, range_agents, range_move, handling_time, regen_time, pTransmit, initialInfections, costInfect, nThreads, dispersal, infect_percent, vertical, mProb, mSize, spillover_rate));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -63,7 +64,7 @@ RcppExport SEXP run_testthat_tests(SEXP);
 
 static const R_CallMethodDef CallEntries[] = {
     {"_pathomove_get_test_landscape", (DL_FUNC) &_pathomove_get_test_landscape, 5},
-    {"_pathomove_run_pathomove", (DL_FUNC) &_pathomove_run_pathomove, 23},
+    {"_pathomove_run_pathomove", (DL_FUNC) &_pathomove_run_pathomove, 24},
     {"run_testthat_tests", (DL_FUNC) &run_testthat_tests, 1},
     {NULL, NULL, 0}
 };

--- a/src/simulations.cpp
+++ b/src/simulations.cpp
@@ -79,10 +79,12 @@ Rcpp::List simulation::do_simulation() {
         case 3:
             if(gen == gen_init) {
                 pop.introducePathogen(initialInfections);
-                gens_patho_intro.push_back(gen);
+                // gens_patho_intro.push_back(gen);
                 Rcpp::Rcout << "New spillover event occurring at gen:" << gen << "\n";
+                // draw new intro generation
+                gen_init += (gens_to_spillover(rng) + 1); // add one to handle zeroes
             }
-            gen_init += gens_to_spillover(rng);
+            break;
         default:
             break;
         }

--- a/src/simulations.cpp
+++ b/src/simulations.cpp
@@ -113,8 +113,11 @@ Rcpp::List simulation::do_simulation() {
 
             // count associations
             pop.countAssoc(nThreads);
-            if((scenario > 0) && (gen >= gen_init)) {
-                // disease
+            // relate to g_patho_init, which is the point of regime shift
+            // NOT gen_init, which is when pathogens are introduced
+            // this allows for vertical transmission
+            if((scenario > 0) && (gen >= g_patho_init)) {
+                // disease spread
                 pop.pathogenSpread();
             }
 

--- a/src/simulations.h
+++ b/src/simulations.h
@@ -27,7 +27,8 @@ public:
                const bool infect_percent,
                const bool vertical,
                const float mProb,
-               const float mSize):
+               const float mSize,
+               const float spillover_rate):
         // population, food, and data structures
         pop (popsize, range_agents, range_food, range_move, handling_time, pTransmit, vertical),
         food(nItems, landsize, nClusters, clusterSpread, regen_time),
@@ -50,6 +51,7 @@ public:
         initialInfections(initialInfections),
         costInfect(costInfect),
         pTransmit(pTransmit),
+        spillover_rate(spillover_rate),
 
         // parallelisation
         nThreads (nThreads),
@@ -79,6 +81,8 @@ public:
     const int regen_time, initialInfections;
     const float costInfect;
     float pTransmit;
+    const float spillover_rate;
+
     int nThreads;
     const float dispersal;
     const bool infect_percent;

--- a/tests/testthat/test-get_trait_data.R
+++ b/tests/testthat/test-get_trait_data.R
@@ -24,7 +24,8 @@ test_that("Test getting trait data", {
     infect_percent = FALSE,
     vertical = FALSE,
     mProb = 0.001,
-    mSize = 0.001
+    mSize = 0.001,
+    spillover_rate = 0.01
   )
 
   # get trait data from pathomove output

--- a/tests/testthat/test-s4_return.R
+++ b/tests/testthat/test-s4_return.R
@@ -24,7 +24,8 @@ test_that("Pathomove returns S4 output", {
     infect_percent = FALSE,
     vertical = FALSE,
     mProb = 0.001,
-    mSize = 0.001
+    mSize = 0.001,
+    spillover_rate = 0.01
   )
 
   # check is list
@@ -85,7 +86,8 @@ test_that("pathomove fails when infections > agents", {
         infect_percent = FALSE,
         vertical = FALSE,
         mProb = 0.001,
-        mSize = 0.001
+        mSize = 0.001,
+        spillover_rate = 0.01
       )
     }
   )


### PR DESCRIPTION
Adds a new **scenario 3** option, in which the pathogen is introduced in one generation (`g_patho_init`), and then in every i-th generation, where _i_ is drawn from a geometric distrbution, whose parameter _p_ is passed to the argument `spillover_rate`.