### PR TITLE
Technical corrections

### DIFF
--- a/src/agents.cpp
+++ b/src/agents.cpp
@@ -438,7 +438,7 @@ const bool Population::check_reprod_threshold() {
 std::vector<float> Population::handleFitness() {
   Rcpp::NumericVector vecFitness = Rcpp::wrap(energy);
   // random errors in fitness
-  Rcpp::NumericVector rd_fitness = Rcpp::rnorm(nAgents, 0.0f, 0.01f);
+  Rcpp::NumericVector rd_fitness = Rcpp::rnorm(nAgents, 0.0f, 1e-5f);
   vecFitness =
       vecFitness + rd_fitness;  // add error to avoid all energies equal
   vecFitness = (vecFitness - Rcpp::min(vecFitness)) /
@@ -467,7 +467,7 @@ Population::applyReprodThreshold() {
 
   // normalise energy between 0 and 1
   Rcpp::NumericVector vecFitness = Rcpp::wrap(energy_pos);
-  Rcpp::NumericVector rd_fitness = Rcpp::rnorm(agents_remaining, 0.0f, 0.01f);
+  Rcpp::NumericVector rd_fitness = Rcpp::rnorm(agents_remaining, 0.0f, 1e-5f);
   vecFitness =
       vecFitness + rd_fitness;  // add error to avoid all energies equal
 

--- a/src/agents.cpp
+++ b/src/agents.cpp
@@ -190,7 +190,7 @@ void Population::move(const Resources &food, const bool &multithreaded) {
   // make random noise for each individual and each sample
   Rcpp::NumericMatrix noise_v(nAgents, n_samples);
   for (size_t i_ = 0; i_ < n_samples; i_++) {
-    noise_v(Rcpp::_, i_) = Rcpp::rnorm(nAgents, 0.0f, 0.01f);
+    noise_v(Rcpp::_, i_) = Rcpp::rnorm(nAgents, 0.0f, 1e-5f);
   }
 
   // loop over agents
@@ -229,10 +229,6 @@ void Population::move(const Resources &food, const bool &multithreaded) {
                 // use range for agents to determine sample locs
                 float sampleX = coordX[i] + (range_agents * cos(j.first));
                 float sampleY = coordY[i] + (range_agents * sin(j.first));
-
-                // crudely wrap sampling location
-                sampleX = wrap_pos(sampleX, food.dSize);
-                sampleY = wrap_pos(sampleY, food.dSize);
 
                 // count food items at sample location
                 foodHere = countFood(food, sampleX, sampleY);
@@ -299,10 +295,6 @@ void Population::move(const Resources &food, const bool &multithreaded) {
           // use range for agents to determine sample locs
           float sampleX = coordX[i] + (range_agents * cos(j.first));
           float sampleY = coordY[i] + (range_agents * sin(j.first));
-
-          // crudely wrap sampling location
-          sampleX = wrap_pos(sampleX, food.dSize);
-          sampleY = wrap_pos(sampleY, food.dSize);
 
           // count food items at sample location
           foodHere = countFood(food, sampleX, sampleY);

--- a/src/agents.cpp
+++ b/src/agents.cpp
@@ -168,16 +168,7 @@ std::vector<int> Population::getFoodId(const Resources &food, const float &xloc,
 // we assume values that are at most a little larger than max (max + 1) and
 // a little smaller than zero (-1)
 float wrap_pos(const float &p1, const float &pmax) {
-  if (std::fabs(p1 / pmax) > 2.f) {
-    Rcpp::stop("Individuals moving far past boundary!\n");
-  }
-  if (p1 > pmax) {
-    return p1 - pmax;
-  }
-  if (p1 < 0.f) {
-    return pmax + p1;
-  }
-  return p1;
+  return p1 - pmax * std::floorf(p1 / pmax);
 }
 
 /// population movement function

--- a/src/agents.cpp
+++ b/src/agents.cpp
@@ -445,12 +445,12 @@ const bool Population::check_reprod_threshold() {
 /// minor function to normalise vector
 std::vector<float> Population::handleFitness() {
   Rcpp::NumericVector vecFitness = Rcpp::wrap(energy);
-  vecFitness = (vecFitness - Rcpp::min(vecFitness)) /
-               (Rcpp::max(vecFitness) - Rcpp::min(vecFitness));
   // random errors in fitness
   Rcpp::NumericVector rd_fitness = Rcpp::rnorm(nAgents, 0.0f, 0.01f);
   vecFitness =
       vecFitness + rd_fitness;  // add error to avoid all energies equal
+  vecFitness = (vecFitness - Rcpp::min(vecFitness)) /
+               (Rcpp::max(vecFitness) - Rcpp::min(vecFitness));
 
   return Rcpp::as<std::vector<float>>(vecFitness);
 }

--- a/src/agents.cpp
+++ b/src/agents.cpp
@@ -163,14 +163,6 @@ std::vector<int> Population::getFoodId(const Resources &food, const float &xloc,
   return food_id;
 }
 
-/// simple wrapping function
-// because std::fabs + std::fmod is somewhat suspicious
-// we assume values that are at most a little larger than max (max + 1) and
-// a little smaller than zero (-1)
-float wrap_pos(const float &p1, const float &pmax) {
-  return p1 - pmax * std::floorf(p1 / pmax);
-}
-
 /// population movement function
 void Population::move(const Resources &food, const bool &multithreaded) {
   const float twopi = 2.f * M_PI;

--- a/src/agents.cpp
+++ b/src/agents.cpp
@@ -57,9 +57,9 @@ void Population::initPos(const Resources &food) {
 // set agent trait
 void Population::setTrait(const float &mSize) {
   // create a cauchy distribution, mSize is the scale
-  sF = Rcpp::as<std::vector<float>>(Rcpp::rcauchy(nAgents, 0.0, mSize));
-  sH = Rcpp::as<std::vector<float>>(Rcpp::rcauchy(nAgents, 0.0, mSize));
-  sN = Rcpp::as<std::vector<float>>(Rcpp::rcauchy(nAgents, 0.0, mSize));
+  sF = Rcpp::as<std::vector<float>>(Rcpp::rnorm(nAgents, 0.0, mSize));
+  sH = Rcpp::as<std::vector<float>>(Rcpp::rnorm(nAgents, 0.0, mSize));
+  sN = Rcpp::as<std::vector<float>>(Rcpp::rnorm(nAgents, 0.0, mSize));
 }
 
 // general function for agents within distance

--- a/src/agents.cpp
+++ b/src/agents.cpp
@@ -113,11 +113,11 @@ std::vector<int> Population::getNeighbourId(const float &xloc,
 int Population::countFood(const Resources &food, const float &xloc,
                           const float &yloc) {
   int nFood = 0;
-  std::vector<value> near_food;
 
   // check any available
   if (food.nAvailable > 0) {
     // query for a simple box
+    std::vector<value> near_food;
     food.rtree.query(bgi::satisfies([&](value const &v) {
                        return bg::distance(v.first, point(xloc, yloc)) <
                               range_food;
@@ -140,10 +140,10 @@ int Population::countFood(const Resources &food, const float &xloc,
 std::vector<int> Population::getFoodId(const Resources &food, const float &xloc,
                                        const float &yloc) {
   std::vector<int> food_id;
-  std::vector<value> near_food;
   // check any available
   if (food.nAvailable > 0) {
     // query for a simple box
+    std::vector<value> near_food;
     // food is accessed over the MOVEMENT RANGE
     food.rtree.query(bgi::satisfies([&](value const &v) {
                        return bg::distance(v.first, point(xloc, yloc)) <
@@ -200,8 +200,7 @@ void Population::move(const Resources &food, const bool &multithreaded) {
               // implicit conversion from int to float as ints are promoted
               float suit_origin = (sF[i] * foodHere) +
                                   (sH[i] * agentCounts.first) +
-                                  (sN[i] * agentCounts.second) +
-                                  noise_v(i, 0);
+                                  (sN[i] * agentCounts.second) + noise_v(i, 0);
               float suit_dest = suit_origin;
 
               // does the agent move at all? initially set to false
@@ -221,9 +220,8 @@ void Population::move(const Resources &food, const bool &multithreaded) {
                 // count handlers and non-handlers at sample location
                 agentCounts = countAgents(sampleX, sampleY);
 
-                suit_dest =
-                    (sF[i] * foodHere) + (sH[i] * agentCounts.first) +
-                    (sN[i] * agentCounts.second) + noise_v(i, j.second);
+                suit_dest = (sF[i] * foodHere) + (sH[i] * agentCounts.first) +
+                            (sN[i] * agentCounts.second) + noise_v(i, j.second);
 
                 if (suit_dest > suit_origin) {
                   // the agent moves
@@ -239,7 +237,7 @@ void Population::move(const Resources &food, const bool &multithreaded) {
               moved[i] += (agent_moves ? range_move : 0.f);
 
               if (agent_moves) {
-                if(choice < 0.f) {
+                if (choice < 0.f) {
                   Rcpp::stop("Error: Agent moved but choice not logged");
                 }
                 // which angle does the agent move to // agent_moves promoted
@@ -290,7 +288,7 @@ void Population::move(const Resources &food, const bool &multithreaded) {
           agentCounts = countAgents(sampleX, sampleY);
 
           suit_dest = (sF[i] * foodHere) + (sH[i] * agentCounts.first) +
-                            (sN[i] * agentCounts.second) + noise_v(i, j.second);
+                      (sN[i] * agentCounts.second) + noise_v(i, j.second);
 
           if (suit_dest > suit_origin) {
             // the agent moves
@@ -306,7 +304,7 @@ void Population::move(const Resources &food, const bool &multithreaded) {
         moved[i] += (agent_moves ? range_move : 0.f);
 
         if (agent_moves) {
-          if(choice < 0.f) {
+          if (choice < 0.f) {
             Rcpp::stop("Error: Agent moved but choice not logged");
           }
           // which angle does the agent move to // agent_moves promoted
@@ -392,7 +390,7 @@ void Population::doForage(Resources &food) {
       // IFF the item is available, then harvest it and mark it as unavailable
       if (food.available[thisItem]) {
         counter[id] = handling_time;
-        intake[id] += 1.0;  // increased here --- not as described.
+        intake[id] += 1.f;  // increased here --- not as described.
 
         // reset food availability
         food.available[thisItem] = false;

--- a/src/agents.cpp
+++ b/src/agents.cpp
@@ -492,9 +492,6 @@ void Population::Reproduce(const Resources &food, const bool &infect_percent,
     thresholded_parents = applyReprodThreshold();
     vecFitness = thresholded_parents.second;
   }
-  if (infect_percent) {
-    vecFitness = energy;
-  }
 
   // set up weighted lottery based on the vector of fitnesses
   std::discrete_distribution<> weightedLottery(vecFitness.begin(),
@@ -613,12 +610,12 @@ void Population::Reproduce(const Resources &food, const bool &infect_percent,
   tmp_sN.clear();
 
   // swap energy
-  std::vector<float> tmpEnergy(nAgents, 0.001);
+  std::vector<float> tmpEnergy(nAgents, 0.f);
   std::swap(energy, tmpEnergy);
   tmpEnergy.clear();
 
   // swap intake
-  std::vector<float> tmpIntake(nAgents, 0.001);
+  std::vector<float> tmpIntake(nAgents, 0.f);
   std::swap(intake, tmpIntake);
   tmpIntake.clear();
 }

--- a/src/landscape.cpp
+++ b/src/landscape.cpp
@@ -21,7 +21,7 @@ std::mt19937 rng;
 // we assume values that are at most a little larger than max (max + 1) and
 // a little smaller than zero (-1)
 float wrap_pos(const float &p1, const float &pmax) {
-  return p1 - pmax * std::floorf(p1 / pmax);
+  return p1 - pmax * std::floor(p1 / pmax);
 }
 
 void Resources::initResources() {

--- a/src/landscape.cpp
+++ b/src/landscape.cpp
@@ -28,10 +28,14 @@ void Resources::initResources() {
   // generate n central items
   std::vector<float> centreCoordX(nClusters);
   std::vector<float> centreCoordY(nClusters);
+  const float padded_size_max = dSize * 0.95f;
+  const float padded_size_min = dSize * 0.05f;
 
   // make item and cluster coords
-  Rcpp::NumericVector cluster_rd_x = Rcpp::runif(nClusters, 0.0f, dSize);
-  Rcpp::NumericVector cluster_rd_y = Rcpp::runif(nClusters, 0.0f, dSize);
+  Rcpp::NumericVector cluster_rd_x =
+      Rcpp::runif(nClusters, padded_size_min, padded_size_max);
+  Rcpp::NumericVector cluster_rd_y =
+      Rcpp::runif(nClusters, padded_size_min, padded_size_max);
 
   Rcpp::NumericVector rd_x = Rcpp::rnorm(nItems, 0.0f, clusterSpread);
   Rcpp::NumericVector rd_y = Rcpp::rnorm(nItems, 0.0f, clusterSpread);
@@ -42,7 +46,7 @@ void Resources::initResources() {
   }
 
   // generate items around
-  for (int i = nClusters; i < nItems; i++) {
+  for (int i = 0; i < nItems; i++) {
     coordX[i] = (centreCoordX[(i % nClusters)] + rd_x(i));
     coordY[i] = (centreCoordY[(i % nClusters)] + rd_y(i));
 

--- a/src/landscape.cpp
+++ b/src/landscape.cpp
@@ -16,6 +16,14 @@
 
 std::mt19937 rng;
 
+/// simple wrapping function
+// because std::fabs + std::fmod is somewhat suspicious
+// we assume values that are at most a little larger than max (max + 1) and
+// a little smaller than zero (-1)
+float wrap_pos(const float &p1, const float &pmax) {
+  return p1 - pmax * std::floorf(p1 / pmax);
+}
+
 void Resources::initResources() {
   // generate n central items
   std::vector<float> centreCoordX(nClusters);
@@ -39,8 +47,8 @@ void Resources::initResources() {
     coordY[i] = (centreCoordY[(i % nClusters)] + rd_y(i));
 
     // wrap
-    coordX[i] = fmod(dSize + coordX[i], dSize);
-    coordY[i] = fmod(dSize + coordY[i], dSize);
+    coordX[i] = wrap_pos(dSize + coordX[i], dSize);
+    coordY[i] = wrap_pos(dSize + coordY[i], dSize);
   }
 
   // initialise rtree and set counter value

--- a/src/landscape.h
+++ b/src/landscape.h
@@ -61,4 +61,6 @@ struct Resources {
   void regenerate();
 };
 
+float wrap_pos(const float &p1, const float &pmax);
+
 #endif  // SRC_LANDSCAPE_H_

--- a/src/pathospread.cpp
+++ b/src/pathospread.cpp
@@ -31,7 +31,7 @@ void Population::introducePathogen(const int initialInfections) {
 void Population::pathogenSpread() {
   // looping through agents, query rtree for neighbours
   // pathogen spreads in random order
-  shufflePop(); 
+  shufflePop();
   for (int i = 0; i < nAgents; i++) {
     // spread to neighbours if self infected
     size_t id = order[i];

--- a/src/pathospread.cpp
+++ b/src/pathospread.cpp
@@ -30,12 +30,15 @@ void Population::introducePathogen(const int initialInfections) {
 /// function to spread pathogen
 void Population::pathogenSpread() {
   // looping through agents, query rtree for neighbours
+  // pathogen spreads in random order
+  shufflePop(); 
   for (int i = 0; i < nAgents; i++) {
     // spread to neighbours if self infected
-    if (infected[i]) {
-      timeInfected[i]++;  // increase time infecetd
+    size_t id = order[i];
+    if (infected[id]) {
+      timeInfected[id]++;  // increase time infecetd
       // get neigbour ids
-      std::vector<int> nbrsId = getNeighbourId(coordX[i], coordY[i]);
+      std::vector<int> nbrsId = getNeighbourId(coordX[id], coordY[id]);
 
       if (nbrsId.size() > 0) {
         // draw whether neighbours will be infected
@@ -49,7 +52,7 @@ void Population::pathogenSpread() {
             // infect neighbours with prob p
             if (transmission(j)) {
               infected[toInfect] = true;
-              srcInfect[toInfect] = i;
+              srcInfect[toInfect] = id;
             }
           }
         }

--- a/src/test_wrapping.cpp
+++ b/src/test_wrapping.cpp
@@ -11,25 +11,14 @@
 // header file.
 #include <testthat.h>
 
-#include "agents.h"
-
-// identical function as linking doesn't work
-float wrap_pos_2(const float &p1, const float &pmax) {
-  if (p1 > pmax) {
-    return p1 - pmax;
-  }
-  if (p1 < 0.f) {
-    return pmax + p1;
-  }
-  return p1;
-}
+#include "landscape.h"
 
 context("Position wrapping works") {
   const float landsize = 10.f;
   const float pos_over = 11.13f;
   const float pos_under = -1.13f;
-  float wrapped_over = wrap_pos_2(pos_over, landsize);
-  float wrapped_under = wrap_pos_2(pos_under, landsize);
+  float wrapped_over = wrap_pos(pos_over, landsize);
+  float wrapped_under = wrap_pos(pos_under, landsize);
   test_that("Position wrapping works") {
     CATCH_CHECK(wrapped_over == Approx(pos_over - landsize).epsilon(1e-3));
     CATCH_CHECK(wrapped_under == Approx(landsize + pos_under).epsilon(1e-3));


### PR DESCRIPTION
This pull request  adds a few technical changes:
1. Correct handling of `vec_fitness` in `handleFitness`,
2. Smaller error for movement decisions, and no wrapping for movement sensing (this is because the agent and food counting functions are not wrapped),
3. Initial agent traits are drawn from a normal distributions; individuals have energy and intake = 0.f after initial reproduction [this is due to a potential error with initialising these as 0.f vectors],
4. A more robust implementation of the wrapping function to return $x - y*floor(y/x)$, where $x$ is the actual coordinate, and $y$ is the maximum coordinate possible; added a test for this function,
5. The wrapping function moved to `landscape.cpp` to use for wrapping item positions; items and clusters are initialised at some distance from landscape edges,
6. Pathogen spread happens in random order,
7. Adding an explicit test for exploitation competition to avoid the error corrected in #35