### PR TITLE
Improve reproducibility

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -73,8 +73,8 @@ get_test_landscape <- function(nItems, landsize, nClusters, clusterSpread, regen
 #' @param spillover_rate For scenario 3, the probability parameter _p_ of a
 #' geometric distribution from which the number of generations until the next
 #' pathogen introduction are drawn.
-#' @param seed An integer number that is the seed for the R RNG as well as the
-#' C++ RNG.
+#' @param seed An integer number that is the seed for the R RNG. Defaults to
+#' zero.
 #'
 #' @return An S4 class, `pathomove_output`, with simulation outcomes.
 #' @export

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -73,9 +73,12 @@ get_test_landscape <- function(nItems, landsize, nClusters, clusterSpread, regen
 #' @param spillover_rate For scenario 3, the probability parameter _p_ of a
 #' geometric distribution from which the number of generations until the next
 #' pathogen introduction are drawn.
+#' @param seed An integer number that is the seed for the R RNG as well as the
+#' C++ RNG.
+#'
 #' @return An S4 class, `pathomove_output`, with simulation outcomes.
 #' @export
-run_pathomove <- function(scenario = 1L, popsize = 100L, nItems = 1800L, landsize = 60.0, nClusters = 60L, clusterSpread = 1.0, tmax = 100L, genmax = 100L, g_patho_init = 70L, n_samples = 5L, range_food = 1.0, range_agents = 1.0, range_move = 1.0, handling_time = 5L, regen_time = 50L, pTransmit = 0.05, p_v_transmit = 0.05, initialInfections = 20L, costInfect = 0.25, multithreaded = TRUE, dispersal = 2.0, infect_percent = FALSE, vertical = FALSE, reprod_threshold = FALSE, mProb = 0.01, mSize = 0.01, spillover_rate = 1.0) {
-    .Call(`_pathomove_run_pathomove`, scenario, popsize, nItems, landsize, nClusters, clusterSpread, tmax, genmax, g_patho_init, n_samples, range_food, range_agents, range_move, handling_time, regen_time, pTransmit, p_v_transmit, initialInfections, costInfect, multithreaded, dispersal, infect_percent, vertical, reprod_threshold, mProb, mSize, spillover_rate)
+run_pathomove <- function(scenario = 1L, popsize = 100L, nItems = 1800L, landsize = 60.0, nClusters = 60L, clusterSpread = 1.0, tmax = 100L, genmax = 100L, g_patho_init = 70L, n_samples = 5L, range_food = 1.0, range_agents = 1.0, range_move = 1.0, handling_time = 5L, regen_time = 50L, pTransmit = 0.05, p_v_transmit = 0.05, initialInfections = 20L, costInfect = 0.25, multithreaded = TRUE, dispersal = 2.0, infect_percent = FALSE, vertical = FALSE, reprod_threshold = FALSE, mProb = 0.01, mSize = 0.01, spillover_rate = 1.0, seed = 0L) {
+    .Call(`_pathomove_run_pathomove`, scenario, popsize, nItems, landsize, nClusters, clusterSpread, tmax, genmax, g_patho_init, n_samples, range_food, range_agents, range_move, handling_time, regen_time, pTransmit, p_v_transmit, initialInfections, costInfect, multithreaded, dispersal, infect_percent, vertical, reprod_threshold, mProb, mSize, spillover_rate, seed)
 }
 

--- a/man/run_pathomove.Rd
+++ b/man/run_pathomove.Rd
@@ -31,7 +31,8 @@ run_pathomove(
   reprod_threshold = FALSE,
   mProb = 0.01,
   mSize = 0.01,
-  spillover_rate = 1
+  spillover_rate = 1,
+  seed = 0L
 )
 }
 \arguments{
@@ -115,6 +116,9 @@ parameter of a Cauchy distribution.}
 \item{spillover_rate}{For scenario 3, the probability parameter \emph{p} of a
 geometric distribution from which the number of generations until the next
 pathogen introduction are drawn.}
+
+\item{seed}{An integer number that is the seed for the R RNG as well as the
+C++ RNG.}
 }
 \value{
 An S4 class, \code{pathomove_output}, with simulation outcomes.

--- a/man/run_pathomove.Rd
+++ b/man/run_pathomove.Rd
@@ -117,8 +117,8 @@ parameter of a Cauchy distribution.}
 geometric distribution from which the number of generations until the next
 pathogen introduction are drawn.}
 
-\item{seed}{An integer number that is the seed for the R RNG as well as the
-C++ RNG.}
+\item{seed}{An integer number that is the seed for the R RNG. Defaults to
+zero.}
 }
 \value{
 An S4 class, \code{pathomove_output}, with simulation outcomes.

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -26,8 +26,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // run_pathomove
-Rcpp::S4 run_pathomove(const int scenario, const int popsize, const int nItems, const float landsize, const int nClusters, const float clusterSpread, const int tmax, const int genmax, const int g_patho_init, const int n_samples, const float range_food, const float range_agents, const float range_move, const int handling_time, const int regen_time, float pTransmit, const float p_v_transmit, const int initialInfections, const float costInfect, const bool multithreaded, const float dispersal, const bool infect_percent, const bool vertical, const bool reprod_threshold, const float mProb, const float mSize, const float spillover_rate);
-RcppExport SEXP _pathomove_run_pathomove(SEXP scenarioSEXP, SEXP popsizeSEXP, SEXP nItemsSEXP, SEXP landsizeSEXP, SEXP nClustersSEXP, SEXP clusterSpreadSEXP, SEXP tmaxSEXP, SEXP genmaxSEXP, SEXP g_patho_initSEXP, SEXP n_samplesSEXP, SEXP range_foodSEXP, SEXP range_agentsSEXP, SEXP range_moveSEXP, SEXP handling_timeSEXP, SEXP regen_timeSEXP, SEXP pTransmitSEXP, SEXP p_v_transmitSEXP, SEXP initialInfectionsSEXP, SEXP costInfectSEXP, SEXP multithreadedSEXP, SEXP dispersalSEXP, SEXP infect_percentSEXP, SEXP verticalSEXP, SEXP reprod_thresholdSEXP, SEXP mProbSEXP, SEXP mSizeSEXP, SEXP spillover_rateSEXP) {
+Rcpp::S4 run_pathomove(const int scenario, const int popsize, const int nItems, const float landsize, const int nClusters, const float clusterSpread, const int tmax, const int genmax, const int g_patho_init, const int n_samples, const float range_food, const float range_agents, const float range_move, const int handling_time, const int regen_time, float pTransmit, const float p_v_transmit, const int initialInfections, const float costInfect, const bool multithreaded, const float dispersal, const bool infect_percent, const bool vertical, const bool reprod_threshold, const float mProb, const float mSize, const float spillover_rate, const int seed);
+RcppExport SEXP _pathomove_run_pathomove(SEXP scenarioSEXP, SEXP popsizeSEXP, SEXP nItemsSEXP, SEXP landsizeSEXP, SEXP nClustersSEXP, SEXP clusterSpreadSEXP, SEXP tmaxSEXP, SEXP genmaxSEXP, SEXP g_patho_initSEXP, SEXP n_samplesSEXP, SEXP range_foodSEXP, SEXP range_agentsSEXP, SEXP range_moveSEXP, SEXP handling_timeSEXP, SEXP regen_timeSEXP, SEXP pTransmitSEXP, SEXP p_v_transmitSEXP, SEXP initialInfectionsSEXP, SEXP costInfectSEXP, SEXP multithreadedSEXP, SEXP dispersalSEXP, SEXP infect_percentSEXP, SEXP verticalSEXP, SEXP reprod_thresholdSEXP, SEXP mProbSEXP, SEXP mSizeSEXP, SEXP spillover_rateSEXP, SEXP seedSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -58,7 +58,8 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const float >::type mProb(mProbSEXP);
     Rcpp::traits::input_parameter< const float >::type mSize(mSizeSEXP);
     Rcpp::traits::input_parameter< const float >::type spillover_rate(spillover_rateSEXP);
-    rcpp_result_gen = Rcpp::wrap(run_pathomove(scenario, popsize, nItems, landsize, nClusters, clusterSpread, tmax, genmax, g_patho_init, n_samples, range_food, range_agents, range_move, handling_time, regen_time, pTransmit, p_v_transmit, initialInfections, costInfect, multithreaded, dispersal, infect_percent, vertical, reprod_threshold, mProb, mSize, spillover_rate));
+    Rcpp::traits::input_parameter< const int >::type seed(seedSEXP);
+    rcpp_result_gen = Rcpp::wrap(run_pathomove(scenario, popsize, nItems, landsize, nClusters, clusterSpread, tmax, genmax, g_patho_init, n_samples, range_food, range_agents, range_move, handling_time, regen_time, pTransmit, p_v_transmit, initialInfections, costInfect, multithreaded, dispersal, infect_percent, vertical, reprod_threshold, mProb, mSize, spillover_rate, seed));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -67,7 +68,7 @@ RcppExport SEXP run_testthat_tests(SEXP);
 
 static const R_CallMethodDef CallEntries[] = {
     {"_pathomove_get_test_landscape", (DL_FUNC) &_pathomove_get_test_landscape, 5},
-    {"_pathomove_run_pathomove", (DL_FUNC) &_pathomove_run_pathomove, 27},
+    {"_pathomove_run_pathomove", (DL_FUNC) &_pathomove_run_pathomove, 28},
     {"run_testthat_tests", (DL_FUNC) &run_testthat_tests, 1},
     {NULL, NULL, 0}
 };

--- a/src/agents.cpp
+++ b/src/agents.cpp
@@ -493,7 +493,7 @@ void Population::Reproduce(const Resources &food, const bool &infect_percent,
     thresholded_parents = applyReprodThreshold();
     vecFitness = Rcpp::wrap(thresholded_parents.second);
     // pick only thresholded parents
-    parent_id = Rcpp::wrap(thresholded_parents.first);
+    parent_identities = Rcpp::wrap(thresholded_parents.first);
   }
 
   // Sample parents vector using the weights from vecFitness

--- a/src/agents.cpp
+++ b/src/agents.cpp
@@ -422,7 +422,7 @@ const bool Population::check_reprod_threshold() {
 }
 
 /// minor function to normalise vector
-std::vector<float> Population::handleFitness() {
+Rcpp::NumericVector Population::handleFitness() {
   Rcpp::NumericVector vecFitness = Rcpp::wrap(energy);
   // random errors in fitness
   Rcpp::NumericVector rd_fitness = Rcpp::rnorm(nAgents, 0.0f, 1e-5f);
@@ -431,7 +431,7 @@ std::vector<float> Population::handleFitness() {
   vecFitness = (vecFitness - Rcpp::min(vecFitness)) /
                (Rcpp::max(vecFitness) - Rcpp::min(vecFitness));
 
-  return Rcpp::as<std::vector<float>>(vecFitness);
+  return vecFitness;
 }
 
 /// prepare function to handle fitness and offer parents when applying a
@@ -475,10 +475,13 @@ void Population::Reproduce(const Resources &food, const bool &infect_percent,
 
   // prepare to deal with fitness and reproduction options
   std::pair<std::vector<int>, std::vector<float>> thresholded_parents;
-  std::vector<float> vecFitness = handleFitness();
+  Rcpp::NumericVector vecFitness = handleFitness();
+
+  // prepare parent identity vector
+  Rcpp::IntegerVector parent_identities = Rcpp::seq(0, nAgents - 1);
 
   if (infect_percent) {
-    vecFitness = energy;
+    vecFitness = Rcpp::wrap(energy);
   }
   // handle vecFtiness (parents) in special cases
   if (reprod_threshold && infect_percent) {
@@ -488,12 +491,15 @@ void Population::Reproduce(const Resources &food, const bool &infect_percent,
   }
   if (reprod_threshold) {
     thresholded_parents = applyReprodThreshold();
-    vecFitness = thresholded_parents.second;
+    vecFitness = Rcpp::wrap(thresholded_parents.second);
+    // pick only thresholded parents
+    parent_id = Rcpp::wrap(thresholded_parents.first);
   }
 
-  // set up weighted lottery based on the vector of fitnesses
-  std::discrete_distribution<> weightedLottery(vecFitness.begin(),
-                                               vecFitness.end());
+  // Sample parents vector using the weights from vecFitness
+  // With replacement is true
+  Rcpp::IntegerVector chosen_parents =
+      Rcpp::sample(parent_identities, nAgents, true, vecFitness);
 
   // get parent trait based on weighted lottery
   std::vector<float> tmp_sF(nAgents, 0.f);
@@ -524,11 +530,11 @@ void Population::Reproduce(const Resources &food, const bool &infect_percent,
   Rcpp::NumericVector sprout_y = Rcpp::rnorm(nAgents, 0.0f, dispersal);
 
   for (int a = 0; a < nAgents; a++) {
-    size_t parent_id = static_cast<size_t>(weightedLottery(rng));
+    size_t parent_id = chosen_parents[a];
 
     // mod the parent id if a reprod threshold is applied, this helps refer
     // to the id in the thresholded parents vector
-    if (reprod_threshold) parent_id = thresholded_parents.first[parent_id];
+    // if (reprod_threshold) parent_id = thresholded_parents.first[parent_id];
 
     tmp_sF[a] = sF[parent_id];
     tmp_sH[a] = sH[parent_id];

--- a/src/agents.h
+++ b/src/agents.h
@@ -85,7 +85,8 @@ struct Population {
   const int handling_time;
 
   // shuffle vector and transmission
-  std::vector<int> order, forageItem;
+  Rcpp::IntegerVector order;
+  std::vector<int> forageItem;
   std::vector<bool> infected;
   std::vector<int> timeInfected;
   const float pTransmit, p_v_transmit;
@@ -128,7 +129,7 @@ struct Population {
   void doForage(Resources &food);  // NOLINT
 
   // funs to handle fitness and reproduce
-  std::vector<float> handleFitness();
+  Rcpp::NumericVector handleFitness();
   void Reproduce(const Resources &food, const bool &infect_percent,
                  const float &dispersal, const float &mProb,
                  const float &mSize);

--- a/src/landscape.cpp
+++ b/src/landscape.cpp
@@ -16,6 +16,14 @@
 
 std::mt19937 rng;
 
+/// @brief Function to set the R RNG seed
+/// @param seed An integer passed to run_pathomve
+void set_seed(const int &seed) {
+    Rcpp::Environment base_env("package:base");
+    Rcpp::Function set_seed_r = base_env["set.seed"];
+    set_seed_r(seed);
+}
+
 /// simple wrapping function
 // because std::fabs + std::fmod is somewhat suspicious
 // we assume values that are at most a little larger than max (max + 1) and
@@ -106,10 +114,6 @@ Rcpp::DataFrame get_test_landscape(const int nItems, const float landsize,
                                    const int nClusters,
                                    const float clusterSpread,
                                    const int regen_time) {
-  unsigned seed = static_cast<unsigned>(
-      std::chrono::system_clock::now().time_since_epoch().count());
-  rng.seed(seed);
-
   Resources food(nItems, landsize, nClusters, clusterSpread, regen_time);
   food.initResources();
 

--- a/src/landscape.cpp
+++ b/src/landscape.cpp
@@ -19,9 +19,9 @@ std::mt19937 rng;
 /// @brief Function to set the R RNG seed
 /// @param seed An integer passed to run_pathomve
 void set_seed(const int &seed) {
-    Rcpp::Environment base_env("package:base");
-    Rcpp::Function set_seed_r = base_env["set.seed"];
-    set_seed_r(seed);
+  Rcpp::Environment base_env("package:base");
+  Rcpp::Function set_seed_r = base_env["set.seed"];
+  set_seed_r(seed);
 }
 
 /// simple wrapping function

--- a/src/landscape.h
+++ b/src/landscape.h
@@ -63,4 +63,7 @@ struct Resources {
 
 float wrap_pos(const float &p1, const float &pmax);
 
+/// function to set the simulation seed for R RNG
+void set_seed(const int &seed);
+
 #endif  // SRC_LANDSCAPE_H_

--- a/src/simulations.cpp
+++ b/src/simulations.cpp
@@ -14,10 +14,6 @@
 // clang-format on
 
 Rcpp::List simulation::do_simulation() {
-  unsigned seed = static_cast<unsigned>(
-      std::chrono::system_clock::now().time_since_epoch().count());
-  rng.seed(seed);
-
   // prepare landscape and pop
   food.initResources();
   food.countAvailable();
@@ -239,6 +235,9 @@ Rcpp::List simulation::do_simulation() {
 //' @param spillover_rate For scenario 3, the probability parameter _p_ of a
 //' geometric distribution from which the number of generations until the next
 //' pathogen introduction are drawn.
+//' @param seed An integer number that is the seed for the R RNG as well as the
+//' C++ RNG.
+//'
 //' @return An S4 class, `pathomove_output`, with simulation outcomes.
 //' @export
 // [[Rcpp::export]]
@@ -255,7 +254,8 @@ Rcpp::S4 run_pathomove(
     const bool multithreaded = true, const float dispersal = 2.0,
     const bool infect_percent = false, const bool vertical = false,
     const bool reprod_threshold = false, const float mProb = 0.01,
-    const float mSize = 0.01, const float spillover_rate = 1.0) {
+    const float mSize = 0.01, const float spillover_rate = 1.0,
+    const int seed = 0) {
   // check that intial infections is less than popsize
   if (initialInfections > popsize) {
     Rcpp::stop("Error: Initial infections must be less than/equal to popsize");
@@ -266,6 +266,9 @@ Rcpp::S4 run_pathomove(
   if (genmax < 10) {
     Rcpp::warning("Simulation often crashes when 1 < genmax < 10");
   }
+
+  // Prepare R and RNG seed
+  set_seed(seed);
 
   // Prepare data for simulation messages
   // return scenario as string

--- a/src/simulations.cpp
+++ b/src/simulations.cpp
@@ -36,19 +36,19 @@ Rcpp::List simulation::do_simulation() {
   auto gen_spillover_happens =
       Rcpp::rbinom(genmax - g_patho_init, 1, spillover_rate);
   switch (scenario) {
-  case 1:
-    // do nothing as sequence is already prepared
-    break;
-  case 2:
-    // single spillover scenario
-    gens_patho_intro = Rcpp::IntegerVector::create(g_patho_init);
-    break;
-  case 3:
-    // sporadic spillover scenario
-    gens_patho_intro = gens_patho_intro[gen_spillover_happens > 0];
-    break;
-  default:
-    break;
+    case 1:
+      // do nothing as sequence is already prepared
+      break;
+    case 2:
+      // single spillover scenario
+      gens_patho_intro = Rcpp::IntegerVector::create(g_patho_init);
+      break;
+    case 3:
+      // sporadic spillover scenario
+      gens_patho_intro = gens_patho_intro[gen_spillover_happens > 0];
+      break;
+    default:
+      break;
   }
 
   // go over gens
@@ -235,8 +235,8 @@ Rcpp::List simulation::do_simulation() {
 //' @param spillover_rate For scenario 3, the probability parameter _p_ of a
 //' geometric distribution from which the number of generations until the next
 //' pathogen introduction are drawn.
-//' @param seed An integer number that is the seed for the R RNG as well as the
-//' C++ RNG.
+//' @param seed An integer number that is the seed for the R RNG. Defaults to
+//' zero.
 //'
 //' @return An S4 class, `pathomove_output`, with simulation outcomes.
 //' @export
@@ -265,6 +265,12 @@ Rcpp::S4 run_pathomove(
   }
   if (genmax < 10) {
     Rcpp::warning("Simulation often crashes when 1 < genmax < 10");
+  }
+  if (multithreaded) {
+    Rcpp::warning(
+        "Multithreading is on and the simulation is NOT reproducible!\nSet "
+        "`multithreaded = FALSE` for a much slower but completely reproducible "
+        "simulation.");
   }
 
   // Prepare R and RNG seed
@@ -322,8 +328,9 @@ Rcpp::S4 run_pathomove(
               << " Reproduction threshold: "
               << (reprod_threshold ? "On" : "Off") << "\n";
   Rcpp::Rcout << "Pathogen:\n "
-              << "p(Transmit): " << pTransmit << " | p(Vertical transmit): "
-              << (vertical ? p_v_transmit : 0.0) << "\n "
+              << "p(Transmit): " << pTransmit
+              << " | p(Vertical transmit): " << (vertical ? p_v_transmit : 0.0)
+              << "\n "
               << "Cost: " << costInfect
               << " | Initial infections: " << initialInfections << "\n\n";
   /* Messages section ends here */

--- a/src/test_inheritance.cpp
+++ b/src/test_inheritance.cpp
@@ -100,7 +100,7 @@ context("Population inheritance without threshold") {
     // std::cout << "Agent 0 intake = " << pop_3.intake[0] << "\n";
     // std::cout << "Agent 0 energy = " << pop_3.energy[0] << "\n";
 
-    std::vector<float> vfit = pop_3.handleFitness();
+    Rcpp::NumericVector vfit = pop_3.handleFitness();
     for (size_t i = 0; i < popsize; i++) {
       // std::cout << "Agent " << i << " fitness = " << vfit[i] << "\n";
       // check that one of the two has more energy than other agents

--- a/src/test_inheritance_threshold.cpp
+++ b/src/test_inheritance_threshold.cpp
@@ -96,7 +96,7 @@ context("Population inheritance with a threshold") {
     // std::cout << "Agent 0 energy = " << pop_4.energy[0] << "\n";
 
     // check that diseased agent has lowest fitness
-    std::vector<float> vfit = pop_4.handleFitness();
+    Rcpp::NumericVector vfit = pop_4.handleFitness();
     for (size_t i = 0; i < popsize; i++) {
       // std::cout << "Agent " << i << " fitness = " << vfit[i] << "\n";
       if (i > 0) CATCH_CHECK(vfit[0] < vfit[i]);

--- a/tests/testthat/test-set_seed.R
+++ b/tests/testthat/test-set_seed.R
@@ -1,0 +1,116 @@
+#### Check that the single threaded implementation is reproducible ####
+test_that("Setting seed gives reproducible results without multithreading", {
+  # original run
+  run_original <- run_pathomove(
+    scenario = 2,
+    genmax = 10,
+    g_patho_init = 1,
+    p_v_transmit = 0.2,
+    costInfect = 0.25,
+    multithreaded = FALSE,
+    vertical = TRUE,
+    mProb = 0.01,
+    mSize = 0.01,
+    spillover_rate = 0.01,
+    seed = 123
+  )
+
+  # identical replicate with same seed
+  run_replicate <- run_pathomove(
+    scenario = 2,
+    genmax = 10,
+    g_patho_init = 1,
+    p_v_transmit = 0.2,
+    costInfect = 0.25,
+    multithreaded = FALSE,
+    vertical = TRUE,
+    mProb = 0.01,
+    mSize = 0.01,
+    spillover_rate = 0.01,
+    seed = 123
+  )
+
+  # expect identical landscapes
+  expect_identical(
+    run_replicate@landscape,
+    run_original@landscape
+  )
+
+  # expect identical infections over time vectors
+  expect_identical(
+    run_replicate@infections_per_gen,
+    run_original@infections_per_gen
+  )
+
+  # expect identical evolved populations in the final generation
+  pop_original <- get_trait_data(run_original)[gen == max(gen), ]
+  pop_replicate <- get_trait_data(run_replicate)[gen == max(gen), ]
+  expect_identical(
+    pop_replicate,
+    pop_original
+  )
+
+  # check that different seeds give different outputs
+  run_replicate <- run_pathomove(
+    scenario = 2,
+    genmax = 10,
+    g_patho_init = 1,
+    p_v_transmit = 0.2,
+    costInfect = 0.25,
+    multithreaded = FALSE,
+    vertical = TRUE,
+    mProb = 0.01,
+    mSize = 0.01,
+    spillover_rate = 0.01,
+    seed = 0
+  )
+
+  # expect different infections over time vectors
+  expect_error(
+    expect_identical(
+      run_replicate@infections_per_gen,
+      run_original@infections_per_gen
+    )
+  )
+})
+
+#### Check that the multithreaded implementation is not reproducible ####
+test_that("Multithreaded simulation is not reproducible", {
+  # original run
+  run_original <- run_pathomove(
+    scenario = 2,
+    genmax = 10,
+    g_patho_init = 1,
+    p_v_transmit = 0.2,
+    costInfect = 0.25,
+    multithreaded = TRUE,
+    vertical = TRUE,
+    mProb = 0.01,
+    mSize = 0.01,
+    spillover_rate = 0.01,
+    seed = 123
+  )
+
+  # identical replicate with same seed
+  run_replicate <- run_pathomove(
+    scenario = 2,
+    genmax = 10,
+    g_patho_init = 1,
+    p_v_transmit = 0.2,
+    costInfect = 0.25,
+    multithreaded = TRUE,
+    vertical = TRUE,
+    mProb = 0.01,
+    mSize = 0.01,
+    spillover_rate = 0.01,
+    seed = 123
+  )
+
+  # expect different infections over time vectors
+  expect_error(
+    expect_identical(
+      run_replicate@infections_per_gen,
+      run_original@infections_per_gen
+    )
+  )
+})


### PR DESCRIPTION
This PR implements small changes that improve reproducibility. Any simulation run is now fully reproducible so long as the same seed is provided, and **multithreading is turned off**.
1. Allow passing a seed in `run_pathomove()`,
2. Replace `std::discrete_distribution` in the weighted lottery implementation with `Rcpp::sample` with the fitness vector as the weights vector,
3. Add a warning for `multithreaded = TRUE` that these simulation runs are not reproducible,
4. Add tests for reproducibility.